### PR TITLE
feat: WhatsApp notification channel + title case template enums

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,7 @@ class TestUtils:
         "doctype": "WhatsAppTemplate",
         "template_name": "_Test Template",
         "language": "en_US",
-        "template_type": "UTILITY",
+        "template_type": "Utility",
         "message": "Hello {{1}}"
     }
 ]

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Pre-commit is configured to use the following tools for checking and formatting 
 
 - WhatsApp Template management (create, sync, push to Meta)
 - Template variables (named and positional)
-- Button support (QUICK_REPLY, URL, COPY_CODE, PHONE_NUMBER, VOICE_CALL)
-- Template status tracking (PENDING, APPROVED, REJECTED, DELETED)
+- Button support (Quick Reply, URL, Copy Code, Phone Number, Voice Call)
+- Template status tracking (Pending, Approved, Rejected, Deleted)
 
 #### Client API
 

--- a/ui/src/components/Messages/TemplateButtons.vue
+++ b/ui/src/components/Messages/TemplateButtons.vue
@@ -14,10 +14,10 @@ withDefaults(defineProps<TemplateButtonsProps>(), {
 // only emits CSS for class names it can read as complete strings in the source.
 const BUTTON_TYPE_ICONS: Record<WhatsAppTemplateButton["button_type"], Component> = {
 	URL: LucideExternalLink,
-	PHONE_NUMBER: LucidePhone,
-	VOICE_CALL: LucidePhone,
-	COPY_CODE: LucideCopy,
-	QUICK_REPLY: LucideCornerUpLeft,
+	"Phone Number": LucidePhone,
+	"Voice Call": LucidePhone,
+	"Copy Code": LucideCopy,
+	"Quick Reply": LucideCornerUpLeft,
 };
 </script>
 

--- a/ui/src/components/Messages/types.ts
+++ b/ui/src/components/Messages/types.ts
@@ -37,11 +37,11 @@ export interface WhatsAppReaction {
 /** Serves both a sent message's rendered buttons and an unsent template's preview. */
 export interface WhatsAppTemplateButton {
   button_type:
-    | "QUICK_REPLY"
+    | "Quick Reply"
     | "URL"
-    | "COPY_CODE"
-    | "PHONE_NUMBER"
-    | "VOICE_CALL";
+    | "Copy Code"
+    | "Phone Number"
+    | "Voice Call";
   button_text: string;
   url?: string;
   phone_number?: string;
@@ -110,7 +110,7 @@ export interface WhatsAppTemplate {
   message?: string;
   footer?: string;
   header_text?: string;
-  header_type?: "TEXT" | "IMAGE" | "DOCUMENT" | "GIF" | "VIDEO";
+  header_type?: "Text" | "Image" | "Document" | "GIF" | "Video";
   /** DocType the template is bound to; empty for unbound templates */
   reference_doctype?: string;
   /** child table, so it needs its own query — optional for a host supplying its own list */

--- a/whatsapp/hooks.py
+++ b/whatsapp/hooks.py
@@ -86,12 +86,17 @@ app_license = "mit"
 # ------------
 
 # before_install = "whatsapp.install.before_install"
-# after_install = "whatsapp.install.after_install"
+after_install = "whatsapp.install.setup_notification_channel"
+
+# Migration
+# ------------
+
+after_migrate = "whatsapp.install.setup_notification_channel"
 
 # Uninstallation
 # ------------
 
-# before_uninstall = "whatsapp.uninstall.before_uninstall"
+before_uninstall = "whatsapp.install.teardown_notification_channel"
 # after_uninstall = "whatsapp.uninstall.after_uninstall"
 
 # Integration Setup
@@ -164,11 +169,8 @@ scheduler_events = {
 
 # Extend DocType Class
 # ------------------------------
-#
-# Specify custom mixins to extend the standard doctype controller.
-# extend_doctype_class = {
-# 	"Task": "whatsapp.custom.task.CustomTaskMixin"
-# }
+
+extend_doctype_class = {"Notification": "whatsapp.whatsapp.notification_channel.WhatsAppNotificationMixin"}
 
 # Overriding Methods
 # ------------------------------

--- a/whatsapp/install.py
+++ b/whatsapp/install.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+WHATSAPP_CHANNEL = "WhatsApp"
+
+SHOW_FOR_WHATSAPP = f"eval:doc.channel=='{WHATSAPP_CHANNEL}'"
+
+CUSTOM_FIELDS = {
+	"Notification": [
+		{
+			"fieldname": "whatsapp_section",
+			"fieldtype": "Section Break",
+			"label": "WhatsApp",
+			"insert_after": "slack_webhook_url",
+			"depends_on": SHOW_FOR_WHATSAPP,
+		},
+		{
+			"fieldname": "whatsapp_template",
+			"fieldtype": "Link",
+			"label": "WhatsApp Template",
+			"options": "WhatsApp Template",
+			"insert_after": "whatsapp_section",
+			"depends_on": SHOW_FOR_WHATSAPP,
+			"mandatory_depends_on": SHOW_FOR_WHATSAPP,
+		},
+		{
+			"fieldname": "whatsapp_account",
+			"fieldtype": "Link",
+			"label": "WhatsApp Account",
+			"options": "WhatsApp Account",
+			"insert_after": "whatsapp_template",
+			"depends_on": SHOW_FOR_WHATSAPP,
+			"description": "Leave blank to use the default account from WhatsApp Settings",
+		},
+	]
+}
+
+PROPERTY_SETTERS = (
+	("channel", "options"),
+	("subject", "depends_on"),
+	("subject", "mandatory_depends_on"),
+	("message_sb", "depends_on"),
+)
+
+
+def setup_notification_channel() -> None:
+	create_custom_fields(CUSTOM_FIELDS, update=True)
+	_add_channel_option()
+	_show_subject_for_whatsapp()
+	_hide_message_for_whatsapp()
+	frappe.clear_cache(doctype="Notification")
+
+
+def teardown_notification_channel() -> None:
+	for fieldname, property_name in PROPERTY_SETTERS:
+		frappe.db.delete(
+			"Property Setter",
+			{"doc_type": "Notification", "field_name": fieldname, "property": property_name},
+		)
+
+	for field in CUSTOM_FIELDS["Notification"]:
+		name = frappe.db.get_value("Custom Field", {"dt": "Notification", "fieldname": field["fieldname"]})
+		if name:
+			frappe.delete_doc("Custom Field", name, ignore_missing=True)
+
+	frappe.clear_cache(doctype="Notification")
+
+
+def _add_channel_option() -> None:
+	options = _shipped_property("channel", "options")
+	if WHATSAPP_CHANNEL in options.split("\n"):
+		return
+
+	_set_property("channel", "options", f"{options}\n{WHATSAPP_CHANNEL}", "Small Text")
+
+
+def _show_subject_for_whatsapp() -> None:
+	"""Notification.autoname is `subject or notification_title`, and Subject is hidden for every
+	channel but Email and Slack — without this a WhatsApp rule falls back to a hash name."""
+	for property_name in ("depends_on", "mandatory_depends_on"):
+		expression = _shipped_property("subject", property_name)
+		_set_property("subject", property_name, _or_whatsapp(expression), "Code")
+
+
+def _hide_message_for_whatsapp() -> None:
+	expression = _shipped_property("message_sb", "depends_on")
+	_set_property("message_sb", "depends_on", _and_not_whatsapp(expression), "Code")
+
+
+def _shipped_property(fieldname: str, property_name: str) -> str:
+	"""Read from DocField rather than Meta: Property Setters never touch it, so a value changed
+	upstream flows through on the next migrate instead of being frozen at whatever we appended to."""
+	return (
+		frappe.db.get_value("DocField", {"parent": "Notification", "fieldname": fieldname}, property_name)
+		or ""
+	)
+
+
+def _set_property(fieldname: str, property_name: str, value: str, property_type: str) -> None:
+	frappe.make_property_setter(
+		{
+			"doctype": "Notification",
+			"fieldname": fieldname,
+			"property": property_name,
+			"value": value,
+			"property_type": property_type,
+		}
+	)
+
+
+def _or_whatsapp(expression: str) -> str:
+	return f"eval: ({_strip_eval(expression)}) || doc.channel == '{WHATSAPP_CHANNEL}'"
+
+
+def _and_not_whatsapp(expression: str) -> str:
+	return f"eval: ({_strip_eval(expression)}) && doc.channel != '{WHATSAPP_CHANNEL}'"
+
+
+def _strip_eval(expression: str) -> str:
+	return expression.removeprefix("eval:").strip()

--- a/whatsapp/patches.txt
+++ b/whatsapp/patches.txt
@@ -7,3 +7,4 @@ whatsapp.patches.v1_0.rename_whatsapp_to_whatsappcased
 # Patches added in this section will be executed after doctypes are migrated
 whatsapp.patches.v1_0.encrypt_account_access_token
 whatsapp.patches.v1_0.capitalize_template_status
+whatsapp.patches.v1_0.titlecase_template_enums

--- a/whatsapp/patches/v1_0/titlecase_template_enums.py
+++ b/whatsapp/patches/v1_0/titlecase_template_enums.py
@@ -1,0 +1,26 @@
+import frappe
+
+from whatsapp.whatsapp.api.utils import BUTTON_TYPES, HEADER_TYPES, TEMPLATE_TYPES
+
+VARIABLE_FORMATS = {"named": "Named", "positional": "Positional"}
+
+FIELD_MAPPINGS = (
+	("WhatsApp Template", "template_type", TEMPLATE_TYPES),
+	("WhatsApp Template", "header_type", HEADER_TYPES),
+	("WhatsApp Template", "variable_format", VARIABLE_FORMATS),
+	("WhatsApp Template Button", "button_type", BUTTON_TYPES),
+)
+
+
+def execute():
+	"""Rewrite template enum values from Meta's all-caps spelling to the Title Case options.
+
+	Follows capitalize_template_status, which did the same for `status`.
+	"""
+	for doctype, fieldname, mapping in FIELD_MAPPINGS:
+		for old, new in mapping.items():
+			if old == new:
+				continue
+			frappe.db.set_value(doctype, {fieldname: old}, fieldname, new, update_modified=False)
+
+	frappe.db.commit()

--- a/whatsapp/whatsapp/api/test_messages.py
+++ b/whatsapp/whatsapp/api/test_messages.py
@@ -849,7 +849,7 @@ class TestGetMessages(WithoutHostAccessGuards, UnitTestCase):
 						phone_number="",
 					),
 					frappe._dict(
-						button_type="PHONE_NUMBER",
+						button_type="Phone Number",
 						button_text="Call us",
 						url="",
 						phone_number="+15551230000",
@@ -882,7 +882,7 @@ class TestGetMessages(WithoutHostAccessGuards, UnitTestCase):
 					"phone_number": "",
 				},
 				{
-					"button_type": "PHONE_NUMBER",
+					"button_type": "Phone Number",
 					"button_text": "Call us",
 					"url": "",
 					"phone_number": "+15551230000",

--- a/whatsapp/whatsapp/api/utils.py
+++ b/whatsapp/whatsapp/api/utils.py
@@ -168,7 +168,7 @@ def _find_example(variables, var_name: str) -> str:
 
 
 def _build_example(variable_format: str, variables, var_names: list[str]) -> dict:
-	is_positional = variable_format == "positional"
+	is_positional = variable_format == "Positional"
 	if is_positional:
 		return {"body_text": [[_find_example(variables, v) for v in var_names]]}
 	return {
@@ -179,7 +179,7 @@ def _build_example(variable_format: str, variables, var_names: list[str]) -> dic
 
 
 def _build_header_example(variable_format: str, variables, var_names: list[str]) -> dict:
-	is_positional = variable_format == "positional"
+	is_positional = variable_format == "Positional"
 	if is_positional:
 		return {"header_text": [_find_example(variables, v) for v in var_names]}
 	return {
@@ -190,19 +190,19 @@ def _build_header_example(variable_format: str, variables, var_names: list[str])
 
 
 def build_create_template_payload(doc) -> CreateTemplatePayload:
-	variable_format = getattr(doc, "variable_format", None) or "named"
+	variable_format = getattr(doc, "variable_format", None) or "Named"
 	components = []
 
 	if doc.header_type:
-		header = {"type": "HEADER", "format": doc.header_type}
-		if doc.header_type == "TEXT" and doc.header_text:
+		header = {"type": "HEADER", "format": _to_meta(HEADER_TYPES, doc.header_type)}
+		if doc.header_type == "Text" and doc.header_text:
 			header["text"] = doc.header_text
 			header_vars = get_template_variables(doc.header_text)
 			if header_vars:
 				header["example"] = _build_header_example(
 					variable_format, doc.template_variables, header_vars
 				)
-		elif doc.header_type in ("IMAGE", "DOCUMENT", "VIDEO", "GIF") and doc.header_media_handle:
+		elif doc.header_type in MEDIA_HEADER_TYPES and doc.header_media_handle:
 			header["example"] = {"header_handle": [doc.header_media_handle]}
 		components.append(header)
 
@@ -218,12 +218,12 @@ def build_create_template_payload(doc) -> CreateTemplatePayload:
 	if doc.buttons:
 		buttons_payload = []
 		for btn in doc.buttons:
-			if btn.button_type == "COPY_CODE":
+			if btn.button_type == "Copy Code":
 				continue
-			b = {"type": btn.button_type, "text": btn.button_text}
+			b = {"type": _to_meta(BUTTON_TYPES, btn.button_type), "text": btn.button_text}
 			if btn.button_type == "URL":
 				b["url"] = btn.url
-			elif btn.button_type == "PHONE_NUMBER":
+			elif btn.button_type == "Phone Number":
 				b["phone_number"] = btn.phone_number
 			buttons_payload.append(b)
 		if buttons_payload:
@@ -232,11 +232,11 @@ def build_create_template_payload(doc) -> CreateTemplatePayload:
 	payload = {
 		"name": doc.template_name,
 		"language": doc.language,
-		"category": doc.template_type,
+		"category": _to_meta(TEMPLATE_TYPES, doc.template_type),
 		"components": components,
 	}
 
-	if variable_format == "named":
+	if variable_format == "Named":
 		payload["parameter_format"] = "named"
 
 	return payload
@@ -277,10 +277,46 @@ def normalize_template_status(api_status: str) -> str:
 	}.get((api_status or "").upper(), "Pending")
 
 
+# Meta spells its enums in all-caps; stored values follow the framework's Title Case
+# convention. Spelled out rather than derived because .title() mangles URL and GIF.
+TEMPLATE_TYPES = {
+	"UTILITY": "Utility",
+	"MARKETING": "Marketing",
+	"AUTHENTICATION": "Authentication",
+}
+HEADER_TYPES = {
+	"TEXT": "Text",
+	"IMAGE": "Image",
+	"DOCUMENT": "Document",
+	"GIF": "GIF",
+	"VIDEO": "Video",
+}
+BUTTON_TYPES = {
+	"QUICK_REPLY": "Quick Reply",
+	"COPY_CODE": "Copy Code",
+	"URL": "URL",
+	"VOICE_CALL": "Voice Call",
+	"PHONE_NUMBER": "Phone Number",
+}
+
+MEDIA_HEADER_TYPES = ("Image", "Document", "Video", "GIF")
+
+
+def _to_local(mapping: dict[str, str], api_value: str, default: str = "") -> str:
+	return mapping.get((api_value or "").upper(), default)
+
+
+def _to_meta(mapping: dict[str, str], local_value: str) -> str:
+	for api_value, local in mapping.items():
+		if local == local_value:
+			return api_value
+	return local_value
+
+
 def parse_whatsapp_template_to_doc(data: dict) -> ParsedTemplateDoc:
 	doc = {
 		"template_name": data.get("name"),
-		"template_type": data.get("category"),
+		"template_type": _to_local(TEMPLATE_TYPES, data.get("category", ""), "Utility"),
 		"language": data.get("language"),
 		"status": normalize_template_status(data.get("status", "")),
 	}
@@ -297,11 +333,11 @@ def parse_whatsapp_template_to_doc(data: dict) -> ParsedTemplateDoc:
 		comp_type = comp.get("type", "").upper()
 
 		if comp_type == "HEADER":
-			header_type = comp.get("format", "")
-			if header_type.upper() == "TEXT":
+			header_type = _to_local(HEADER_TYPES, comp.get("format", ""))
+			if header_type == "Text":
 				header_text = comp.get("text", "")
 				variable_rows.extend(_resolve_examples(header_text, comp))
-			elif header_type.upper() in ("IMAGE", "DOCUMENT", "VIDEO", "GIF"):
+			elif header_type in MEDIA_HEADER_TYPES:
 				example = comp.get("example", {}) or {}
 				handles = example.get("header_handle", [])
 				if handles:
@@ -319,7 +355,7 @@ def parse_whatsapp_template_to_doc(data: dict) -> ParsedTemplateDoc:
 				btn_url = btn.get("url", "")
 				buttons.append(
 					{
-						"button_type": btn.get("type"),
+						"button_type": _to_local(BUTTON_TYPES, btn.get("type", "")),
 						"button_text": btn.get("text"),
 						"url": btn_url,
 						"phone_number": btn.get("phone_number", ""),
@@ -337,11 +373,11 @@ def parse_whatsapp_template_to_doc(data: dict) -> ParsedTemplateDoc:
 	doc["footer"] = footer
 	doc["buttons"] = buttons
 
-	variable_format = "named"
+	variable_format = "Named"
 	if variable_rows:
 		all_digit = all(v[0].isdigit() for v in variable_rows)
 		if all_digit:
-			variable_format = "positional"
+			variable_format = "Positional"
 	doc["variable_format"] = variable_format
 
 	seen = set()
@@ -382,7 +418,7 @@ def build_template_message_payload(
 		if isinstance(header_parameters, str):
 			header_parameters = json.loads(header_parameters)
 
-		if template_doc.header_type == "TEXT":
+		if template_doc.header_type == "Text":
 			header_vars = get_template_variables(template_doc.header_text)
 			param_name = header_vars[0] if header_vars else "1"
 			components.append(
@@ -398,7 +434,7 @@ def build_template_message_payload(
 				}
 			)
 		else:
-			media_type = template_doc.header_type.lower()
+			media_type = _to_meta(HEADER_TYPES, template_doc.header_type).lower()
 			params = {"id": header_parameters["id"]} if isinstance(header_parameters, dict) else {}
 			if (
 				media_type == "document"

--- a/whatsapp/whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
+++ b/whatsapp/whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
@@ -53,7 +53,7 @@ class IntegrationTestWhatsAppMessage(IntegrationTestCase):
 			doctype="WhatsApp Template",
 			template_label=f"_Test Template {uid}",
 			template_name=f"_test_template_{uid}",
-			template_type="UTILITY",
+			template_type="Utility",
 			language="en_US",
 			message="Plain body text",
 			whatsapp_account=acc,
@@ -266,7 +266,7 @@ class IntegrationTestWhatsAppMessage(IntegrationTestCase):
 		tmpl = self._make_template(
 			template_label="_Test PopHead",
 			template_name="_test_pophead",
-			header_type="TEXT",
+			header_type="Text",
 			header_text="{{description}}",
 			message="Body {{sender}}",
 			reference_doctype="ToDo",
@@ -692,7 +692,7 @@ class IntegrationTestWhatsAppMessage(IntegrationTestCase):
 		tmpl = self._make_template(
 			template_label="_Test Thm",
 			template_name="_test_thm",
-			header_type="IMAGE",
+			header_type="Image",
 			header_media=file_name,
 		)
 		data = self._make_outgoing(is_template=1, whatsapp_template=tmpl)
@@ -715,7 +715,7 @@ class IntegrationTestWhatsAppMessage(IntegrationTestCase):
 		tmpl = self._make_template(
 			template_label="_Test Thm2",
 			template_name="_test_thm2",
-			header_type="IMAGE",
+			header_type="Image",
 			header_media=file_name,
 			header_media_handle="existing_handle",
 		)
@@ -738,7 +738,7 @@ class IntegrationTestWhatsAppMessage(IntegrationTestCase):
 		tmpl = self._make_template(
 			template_label="_Test Thm3",
 			template_name="_test_thm3",
-			header_type="IMAGE",
+			header_type="Image",
 			header_media=file_name,
 		)
 		data = self._make_outgoing(is_template=1, whatsapp_template=tmpl)

--- a/whatsapp/whatsapp/doctype/whatsapp_message/whatsapp_message.py
+++ b/whatsapp/whatsapp/doctype/whatsapp_message/whatsapp_message.py
@@ -10,6 +10,7 @@ from frappe.model.document import Document
 from frappe.utils import now_datetime
 
 from whatsapp.whatsapp.api.utils import (
+	MEDIA_HEADER_TYPES,
 	build_interactive_buttons_payload,
 	build_interactive_list_payload,
 	build_media_message_payload,
@@ -168,7 +169,7 @@ class WhatsAppMessage(Document):
 			value = ref_doc.get(var.variable_field)
 			check_str = f"{{{{{var.variable_name}}}}}"
 			is_header = (
-				template.header_type == "TEXT"
+				template.header_type == "Text"
 				and template.header_text
 				and check_str in template.header_text
 			)
@@ -225,7 +226,7 @@ class WhatsAppMessage(Document):
 
 		if self.is_template and self.whatsapp_template:
 			template_doc = frappe.get_doc("WhatsApp Template", self.whatsapp_template)
-			if template_doc.header_type in ("IMAGE", "DOCUMENT", "VIDEO", "GIF") and template_doc.header_media:
+			if template_doc.header_type in MEDIA_HEADER_TYPES and template_doc.header_media:
 				if not template_doc.header_media_handle:
 					file_doc = frappe.get_doc("File", template_doc.header_media)
 					file_content = file_doc.get_content()
@@ -337,7 +338,7 @@ class WhatsAppMessage(Document):
 			body_params = json.loads(self.template_body_parameters or "{}")
 
 			header_params = self.template_header_parameters
-			if template_doc.header_type in ("IMAGE", "DOCUMENT", "VIDEO", "GIF") and template_doc.header_media_handle:
+			if template_doc.header_type in MEDIA_HEADER_TYPES and template_doc.header_media_handle:
 				if not header_params:
 					header_params = json.dumps({"id": template_doc.header_media_handle})
 

--- a/whatsapp/whatsapp/doctype/whatsapp_template/test_whatsapp_template.py
+++ b/whatsapp/whatsapp/doctype/whatsapp_template/test_whatsapp_template.py
@@ -43,13 +43,13 @@ class IntegrationTestWhatsAppTemplate(IntegrationTestCase):
 			doctype="WhatsApp Template",
 			template_label=template_name,
 			template_name=template_name,
-			template_type="UTILITY",
+			template_type="Utility",
 			language="en_US",
 			message="Hello {{name}}, order {{order_id}}",
 			whatsapp_account=account,
 			whatsapp_template_id=uid,
 			status="Pending",
-			variable_format="named",
+			variable_format="Named",
 			reference_doctype="User",
 			template_variables=[
 				{"variable_name": "name", "variable_example": "John", "variable_field": "full_name"},
@@ -101,7 +101,7 @@ class IntegrationTestWhatsAppTemplate(IntegrationTestCase):
 			doctype="WhatsApp Template",
 			template_label=template_label,
 			template_name=f"_test_push_{uid}",
-			template_type="UTILITY",
+			template_type="Utility",
 			language="en_US",
 			message="Hello world",
 			whatsapp_account=account,
@@ -131,13 +131,13 @@ class IntegrationTestWhatsAppTemplate(IntegrationTestCase):
 			doctype="WhatsApp Template",
 			template_label=template_name,
 			template_name=template_name,
-			template_type="UTILITY",
+			template_type="Utility",
 			language="en_US",
 			message="Hello {{name}}",
 			whatsapp_account=account,
 			whatsapp_template_id=uid,
 			status="Pending",
-			variable_format="named",
+			variable_format="Named",
 			template_variables=[
 				{"variable_name": "name", "variable_example": "John", "variable_field": "full_name"},
 			],
@@ -211,14 +211,14 @@ class IntegrationTestGetSendableTemplates(WithoutHostAccessGuards, IntegrationTe
 				doctype="WhatsApp Template",
 				template_label=name,
 				template_name=name,
-				template_type="UTILITY",
+				template_type="Utility",
 				language="en_US",
 				message=message,
 				whatsapp_account=self.account,
 				# A template id short-circuits the push to Meta on insert.
 				whatsapp_template_id=f"{suffix}_{self.uid}",
 				status=status,
-				variable_format="named",
+				variable_format="Named",
 				reference_doctype=reference_doctype,
 				template_variables=template_variables or [],
 				buttons=buttons or [],
@@ -279,14 +279,14 @@ class IntegrationTestGetSendableTemplates(WithoutHostAccessGuards, IntegrationTe
 			reference_doctype="ToDo",
 			buttons=[
 				{"button_type": "URL", "button_text": "Track", "url": "https://example.com"},
-				{"button_type": "PHONE_NUMBER", "button_text": "Call", "phone_number": "+15551230000"},
+				{"button_type": "Phone Number", "button_text": "Call", "phone_number": "+15551230000"},
 			],
 		)
 		template = next(t for t in get_sendable_templates("ToDo") if t.name == with_buttons)
 
 		self.assertEqual(
 			[(b["button_type"], b["button_text"]) for b in template["buttons"]],
-			[("URL", "Track"), ("PHONE_NUMBER", "Call")],
+			[("URL", "Track"), ("Phone Number", "Call")],
 		)
 		self.assertEqual(template["buttons"][0]["url"], "https://example.com")
 		self.assertEqual(template["buttons"][1]["phone_number"], "+15551230000")
@@ -381,9 +381,9 @@ class TestUtils:
 		doc = _make_mock_doc(
 			template_name="test_template",
 			language="en_US",
-			template_type="UTILITY",
+			template_type="Utility",
 			message="Hello {{name}}",
-			variable_format="named",
+			variable_format="Named",
 			template_variables_data=[("name", "John")],
 		)
 		payload = build_create_template_payload(doc)
@@ -398,9 +398,9 @@ class TestUtils:
 		doc = _make_mock_doc(
 			template_name="test_template",
 			language="en_US",
-			template_type="UTILITY",
+			template_type="Utility",
 			message="Hello {{1}}, order {{2}}",
-			variable_format="positional",
+			variable_format="Positional",
 			template_variables_data=[("1", "John"), ("2", "123")],
 		)
 		payload = build_create_template_payload(doc)
@@ -415,9 +415,9 @@ class TestUtils:
 		doc = _make_mock_doc(
 			template_name="media_test",
 			language="en_US",
-			template_type="MARKETING",
+			template_type="Marketing",
 			message="Check this out",
-			header_type="IMAGE",
+			header_type="Image",
 			header_media_handle="4::aW...",
 		)
 		payload = build_create_template_payload(doc)
@@ -431,11 +431,11 @@ class TestUtils:
 		doc = _make_mock_doc(
 			template_name="header_test",
 			language="en_US",
-			template_type="UTILITY",
+			template_type="Utility",
 			message="Body text",
-			header_type="TEXT",
+			header_type="Text",
 			header_text="Our {{title}}",
-			variable_format="named",
+			variable_format="Named",
 			template_variables_data=[("title", "Summer Sale")],
 		)
 		payload = build_create_template_payload(doc)
@@ -462,7 +462,7 @@ class TestUtils:
 		}
 		result = parse_whatsapp_template_to_doc(data)
 		assert result["header_media_handle"] == "4::aW..."
-		assert result["header_type"] == "IMAGE"
+		assert result["header_type"] == "Image"
 
 	def test_parse_positional_vars_detection(self):
 		from whatsapp.whatsapp.api.utils import parse_whatsapp_template_to_doc
@@ -481,7 +481,7 @@ class TestUtils:
 			],
 		}
 		result = parse_whatsapp_template_to_doc(data)
-		assert result["variable_format"] == "positional"
+		assert result["variable_format"] == "Positional"
 		assert result["template_variables"][0]["variable_name"] == "1"
 
 	def test_parse_named_vars_detection(self):
@@ -501,7 +501,7 @@ class TestUtils:
 			],
 		}
 		result = parse_whatsapp_template_to_doc(data)
-		assert result["variable_format"] == "named"
+		assert result["variable_format"] == "Named"
 
 	def test_build_message_payload_header_params_json_string(self):
 		from whatsapp.whatsapp.api.utils import build_template_message_payload
@@ -509,9 +509,9 @@ class TestUtils:
 		doc = _make_mock_doc(
 			template_name="doc_test",
 			language="en_US",
-			template_type="UTILITY",
+			template_type="Utility",
 			message="Here is your document",
-			header_type="DOCUMENT",
+			header_type="Document",
 		)
 		payload = build_template_message_payload(
 			to="+1234567890",
@@ -520,6 +520,41 @@ class TestUtils:
 		)
 		header_comp = next(c for c in payload["template"]["components"] if c["type"] == "header")
 		assert header_comp["parameters"][0]["document"]["id"] == "media-id-123"
+
+
+class TestEnumMaps:
+	"""Meta spells these all-caps; storage follows the framework's Title Case convention."""
+
+	def test_every_local_value_round_trips_back_to_meta(self):
+		from whatsapp.whatsapp.api.utils import (
+			BUTTON_TYPES,
+			HEADER_TYPES,
+			TEMPLATE_TYPES,
+			_to_local,
+			_to_meta,
+		)
+
+		for mapping in (TEMPLATE_TYPES, HEADER_TYPES, BUTTON_TYPES):
+			for api_value, local in mapping.items():
+				assert _to_local(mapping, api_value) == local
+				assert _to_meta(mapping, local) == api_value
+
+	def test_acronyms_keep_their_casing(self):
+		from whatsapp.whatsapp.api.utils import BUTTON_TYPES, HEADER_TYPES
+
+		assert HEADER_TYPES["GIF"] == "GIF"
+		assert BUTTON_TYPES["URL"] == "URL"
+
+	def test_unknown_api_value_falls_back_to_the_default(self):
+		from whatsapp.whatsapp.api.utils import TEMPLATE_TYPES, _to_local
+
+		assert _to_local(TEMPLATE_TYPES, "SOMETHING_NEW", "Utility") == "Utility"
+		assert _to_local(TEMPLATE_TYPES, "") == ""
+
+	def test_media_header_types_are_the_non_text_locals(self):
+		from whatsapp.whatsapp.api.utils import HEADER_TYPES, MEDIA_HEADER_TYPES
+
+		assert set(MEDIA_HEADER_TYPES) == set(HEADER_TYPES.values()) - {"Text"}
 
 
 def _make_mock_doc(**kwargs):

--- a/whatsapp/whatsapp/doctype/whatsapp_template/whatsapp_template.json
+++ b/whatsapp/whatsapp/doctype/whatsapp_template/whatsapp_template.json
@@ -73,12 +73,12 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "MARKETING",
+   "default": "Marketing",
    "fieldname": "template_type",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Template type",
-   "options": "UTILITY\nMARKETING\nAUTHENTICATION",
+   "options": "Utility\nMarketing\nAuthentication",
    "reqd": 1
   },
   {
@@ -106,14 +106,14 @@
    "show_description_on_click": 1
   },
   {
-   "depends_on": "eval:doc.header_type === \"TEXT\"",
+   "depends_on": "eval:doc.header_type === \"Text\"",
    "description": "Header Text should only have one variable.",
    "fieldname": "header_text",
    "fieldtype": "Data",
    "label": "Header Text"
   },
   {
-   "depends_on": "eval:[\"IMAGE\", \"DOCUMENT\", \"VIDEO\", \"GIF\"].includes(doc.header_type)",
+   "depends_on": "eval:[\"Image\", \"Document\", \"Video\", \"GIF\"].includes(doc.header_type)",
    "fieldname": "header_media",
    "fieldtype": "Attach",
    "label": "Header Media"
@@ -123,11 +123,11 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "TEXT",
+   "default": "Text",
    "fieldname": "header_type",
    "fieldtype": "Select",
    "label": "Header Type",
-   "options": "TEXT\nIMAGE\nDOCUMENT\nGIF\nVIDEO"
+   "options": "Text\nImage\nDocument\nGIF\nVideo"
   },
   {
    "fieldname": "section_break_snmo",
@@ -187,13 +187,13 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "named",
+   "default": "Named",
    "fieldname": "variable_format",
    "fieldtype": "Select",
    "hidden": 1,
    "label": "Variable Format",
    "no_copy": 1,
-   "options": "named\npositional",
+   "options": "Named\nPositional",
    "read_only": 1
   },
    {

--- a/whatsapp/whatsapp/doctype/whatsapp_template/whatsapp_template.py
+++ b/whatsapp/whatsapp/doctype/whatsapp_template/whatsapp_template.py
@@ -37,7 +37,7 @@ class WhatsAppTemplate(Document):
 		header_media: DF.Attach | None
 		header_media_handle: DF.Data | None
 		header_text: DF.Data | None
-		header_type: DF.Literal["TEXT", "IMAGE", "DOCUMENT", "GIF", "VIDEO"]
+		header_type: DF.Literal["Text", "Image", "Document", "GIF", "Video"]
 		language: DF.Literal["en_UK", "en_US", "en"]
 		message: DF.Code
 		mime_type: DF.Data | None
@@ -45,15 +45,15 @@ class WhatsAppTemplate(Document):
 		status: DF.Literal["Pending", "Approved", "Rejected", "Deleted"]
 		template_label: DF.Data
 		template_name: DF.Data | None
-		template_type: DF.Literal["UTILITY", "MARKETING", "AUTHENTICATION"]
+		template_type: DF.Literal["Utility", "Marketing", "Authentication"]
 		template_variables: DF.Table[TemplateVariable]
-		variable_format: DF.Literal["named", "positional"]
+		variable_format: DF.Literal["Named", "Positional"]
 		whatsapp_account: DF.Link | None
 		whatsapp_template_id: DF.Data | None
 	# end: auto-generated types
 
 	def _sync_template_variables(self) -> None:
-		if self.header_text and self.header_type == "TEXT":
+		if self.header_text and self.header_type == "Text":
 			header_variables = get_template_variables(self.header_text)
 		else:
 			header_variables = []
@@ -80,7 +80,7 @@ class WhatsAppTemplate(Document):
 
 	def validate_template_variables(self) -> None:
 		variables = get_template_variables(self.message)
-		if self.header_text and self.header_type == "TEXT":
+		if self.header_text and self.header_type == "Text":
 			variables.extend(get_template_variables(self.header_text))
 
 		if len(variables) != len(self.template_variables):
@@ -202,7 +202,7 @@ class WhatsAppTemplate(Document):
 		whatsapp = _get_whatsapp_client(self.whatsapp_account)
 
 		if not self.variable_format:
-			self.variable_format = "named"
+			self.variable_format = "Named"
 
 		payload = build_create_template_payload(self)
 		logger.info("_push_to_meta | payload=%s", payload)
@@ -281,7 +281,7 @@ class WhatsAppTemplate(Document):
 		whatsapp = _get_whatsapp_client(self.whatsapp_account)
 
 		if not self.variable_format:
-			self.variable_format = "named"
+			self.variable_format = "Named"
 
 		payload = build_create_template_payload(self)
 		payload.pop("name", None)
@@ -417,12 +417,12 @@ def _upsert_template(template_data: dict, account_name: str) -> tuple[str, bool]
 		doc.whatsapp_account = account_name
 		doc.status = parsed.get("status", "Pending")
 		doc.template_type = parsed["template_type"]
-		doc.header_type = parsed.get("header_type", "TEXT")
+		doc.header_type = parsed.get("header_type", "Text")
 		doc.header_text = parsed.get("header_text", "")
 		doc.header_media_handle = parsed.get("header_media_handle", "")
 		doc.message = parsed.get("message", "")
 		doc.footer = parsed.get("footer", "")
-		doc.variable_format = parsed.get("variable_format", "named")
+		doc.variable_format = parsed.get("variable_format", "Named")
 
 		existing_variable_fields = {
 			v.variable_name: v.variable_field for v in doc.template_variables
@@ -455,12 +455,12 @@ def _upsert_template(template_data: dict, account_name: str) -> tuple[str, bool]
 			"status": parsed.get("status", "Pending"),
 			"template_type": parsed["template_type"],
 			"language": parsed["language"],
-			"header_type": parsed.get("header_type", "TEXT"),
+			"header_type": parsed.get("header_type", "Text"),
 			"header_text": parsed.get("header_text", ""),
 			"header_media_handle": parsed.get("header_media_handle", ""),
 			"message": parsed.get("message", ""),
 			"footer": parsed.get("footer", ""),
-			"variable_format": parsed.get("variable_format", "named"),
+			"variable_format": parsed.get("variable_format", "Named"),
 			"template_variables": parsed.get("template_variables", []),
 			"buttons": parsed.get("buttons", []),
 		}

--- a/whatsapp/whatsapp/doctype/whatsapp_template_button/whatsapp_template_button.json
+++ b/whatsapp/whatsapp/doctype/whatsapp_template_button/whatsapp_template_button.json
@@ -17,7 +17,7 @@
    "fieldname": "button_type",
    "fieldtype": "Select",
    "label": "Button Type",
-   "options": "QUICK_REPLY\nCOPY_CODE\nURL\nVOICE_CALL\nPHONE_NUMBER",
+   "options": "Quick Reply\nCopy Code\nURL\nVoice Call\nPhone Number",
    "reqd": 1
   },
   {
@@ -35,11 +35,11 @@
    "mandatory_depends_on": "eval:doc.button_type === \"URL\""
   },
   {
-   "depends_on": "eval:doc.button_type === \"PHONE_NUMBER\"",
+   "depends_on": "eval:doc.button_type === \"Phone Number\"",
    "fieldname": "phone_number",
    "fieldtype": "Data",
    "label": "Phone Number",
-   "mandatory_depends_on": "eval:doc.button_type === \"PHONE_NUMBER\"",
+   "mandatory_depends_on": "eval:doc.button_type === \"Phone Number\"",
    "options": "Phone"
   }
  ],

--- a/whatsapp/whatsapp/doctype/whatsapp_template_button/whatsapp_template_button.py
+++ b/whatsapp/whatsapp/doctype/whatsapp_template_button/whatsapp_template_button.py
@@ -15,7 +15,7 @@ class WhatsAppTemplateButton(Document):
 		from frappe.types import DF
 
 		button_text: DF.Data
-		button_type: DF.Literal["QUICK_REPLY", "COPY_CODE", "URL", "VOICE_CALL", "PHONE_NUMBER"]
+		button_type: DF.Literal["Quick Reply", "Copy Code", "URL", "Voice Call", "Phone Number"]
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data

--- a/whatsapp/whatsapp/notification/whatsapp_message_received/whatsapp_message_received.json
+++ b/whatsapp/whatsapp/notification/whatsapp_message_received/whatsapp_message_received.json
@@ -13,10 +13,12 @@
  "message_type": "HTML",
  "method": "on_receive",
  "minutes_offset": 0,
- "modified": "2026-05-22 15:53:51.484136",
+ "modified": "2026-08-25 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "WhatsApp",
  "name": "WhatsApp Message Received",
+ "notification_message": "{{ message_preview }}",
+ "notification_title": "New WhatsApp message from {{ doc.from or doc.to }}",
  "owner": "Administrator",
  "recipients": [
   {

--- a/whatsapp/whatsapp/notification/whatsapp_message_received/whatsapp_message_received.py
+++ b/whatsapp/whatsapp/notification/whatsapp_message_received/whatsapp_message_received.py
@@ -1,5 +1,30 @@
 import frappe
+from frappe import _
+
+from whatsapp.whatsapp.api.utils import infer_content_type
+
+MEDIA_LABELS = {
+	"image": "Photo",
+	"video": "Video",
+	"audio": "Audio message",
+	"document": "Document",
+}
+
+PREVIEW_LIMIT = 140
 
 
 def get_context(context):
-	pass
+	return {"message_preview": _message_preview(context["doc"])}
+
+
+def _message_preview(doc) -> str:
+	"""One-line body for the in-app notification: the text, or what kind of media arrived."""
+	if doc.message:
+		text = frappe.utils.strip_html(doc.message).strip()
+		if len(text) <= PREVIEW_LIMIT:
+			return text
+		return text[:PREVIEW_LIMIT].rstrip() + "…"
+
+	# infer_content_type returns "text" when there is no MIME type, i.e. no media either
+	label = MEDIA_LABELS.get(infer_content_type(doc.mime_type))
+	return _(label) if label else ""

--- a/whatsapp/whatsapp/notification/whatsapp_message_send_failed/whatsapp_message_send_failed.json
+++ b/whatsapp/whatsapp/notification/whatsapp_message_send_failed/whatsapp_message_send_failed.json
@@ -13,10 +13,12 @@
  "message_type": "HTML",
  "method": "on_send_failed",
  "minutes_offset": 0,
- "modified": "2026-05-22 15:53:51.500046",
+ "modified": "2026-08-25 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "WhatsApp",
  "name": "WhatsApp Message Send Failed",
+ "notification_message": "{{ doc.error_message }}",
+ "notification_title": "WhatsApp message to {{ doc.to }} failed",
  "owner": "Administrator",
  "recipients": [
   {

--- a/whatsapp/whatsapp/notification/whatsapp_message_sent/whatsapp_message_sent.json
+++ b/whatsapp/whatsapp/notification/whatsapp_message_sent/whatsapp_message_sent.json
@@ -13,10 +13,12 @@
  "message_type": "HTML",
  "method": "on_send",
  "minutes_offset": 0,
- "modified": "2026-05-22 15:53:51.447490",
+ "modified": "2026-08-25 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "WhatsApp",
  "name": "WhatsApp Message Sent",
+ "notification_message": "{{ doc.whatsapp_account }} · {{ doc.status }}",
+ "notification_title": "WhatsApp message sent to {{ doc.to }}",
  "owner": "Administrator",
  "recipients": [
   {

--- a/whatsapp/whatsapp/notification/whatsapp_message_status_updated/whatsapp_message_status_updated.json
+++ b/whatsapp/whatsapp/notification/whatsapp_message_status_updated/whatsapp_message_status_updated.json
@@ -13,10 +13,12 @@
  "message_type": "HTML",
  "method": "on_status_update",
  "minutes_offset": 0,
- "modified": "2026-05-22 15:53:51.426860",
+ "modified": "2026-08-25 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "WhatsApp",
  "name": "WhatsApp Message Status Updated",
+ "notification_message": "{{ doc.whatsapp_account }}",
+ "notification_title": "WhatsApp message {{ doc.status }} — {{ doc.to }}",
  "owner": "Administrator",
  "recipients": [
   {

--- a/whatsapp/whatsapp/notification/whatsapp_template_approved/whatsapp_template_approved.json
+++ b/whatsapp/whatsapp/notification/whatsapp_template_approved/whatsapp_template_approved.json
@@ -13,10 +13,12 @@
  "message_type": "HTML",
  "method": "on_template_approved",
  "minutes_offset": 0,
- "modified": "2026-05-22 15:53:51.386128",
+ "modified": "2026-08-25 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "WhatsApp",
  "name": "WhatsApp Template Approved",
+ "notification_message": "{{ doc.template_type }} · {{ doc.language }} · {{ doc.whatsapp_account }}",
+ "notification_title": "Template {{ doc.template_label or doc.template_name }} approved",
  "owner": "Administrator",
  "recipients": [
   {

--- a/whatsapp/whatsapp/notification/whatsapp_template_rejected/whatsapp_template_rejected.json
+++ b/whatsapp/whatsapp/notification/whatsapp_template_rejected/whatsapp_template_rejected.json
@@ -13,10 +13,12 @@
  "message_type": "HTML",
  "method": "on_template_rejected",
  "minutes_offset": 0,
- "modified": "2026-05-22 15:53:51.467738",
+ "modified": "2026-08-25 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "WhatsApp",
  "name": "WhatsApp Template Rejected",
+ "notification_message": "{{ doc.template_type }} · {{ doc.language }} · {{ doc.whatsapp_account }}",
+ "notification_title": "Template {{ doc.template_label or doc.template_name }} rejected",
  "owner": "Administrator",
  "recipients": [
   {

--- a/whatsapp/whatsapp/notification_channel.py
+++ b/whatsapp/whatsapp/notification_channel.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.email.doctype.notification.notification import (
+	get_reference_doctype,
+	get_reference_name,
+)
+
+from whatsapp.install import WHATSAPP_CHANNEL
+from whatsapp.whatsapp.api.utils import log
+from whatsapp.whatsapp.doctype.whatsapp_profile.whatsapp_profile import get_or_create_profile
+
+
+class WhatsAppNotificationMixin:
+	"""Adds the WhatsApp channel to Notification."""
+
+	def validate(self) -> None:
+		super().validate()
+		if self.channel == WHATSAPP_CHANNEL:
+			self._validate_whatsapp()
+
+	def _validate_whatsapp(self) -> None:
+		# mandatory_depends_on is only enforced client-side, so the API path arrives here unchecked
+		if not self.get("whatsapp_template"):
+			frappe.throw(_("WhatsApp Template is required for the WhatsApp channel"))
+		if not self.subject:
+			frappe.throw(_("Subject is required — it names the notification"))
+
+		template = frappe.get_cached_doc("WhatsApp Template", self.get("whatsapp_template"))
+		if template.status != "Approved":
+			frappe.throw(
+				_("Template {0} is {1} — only Approved templates can be sent").format(
+					template.name, template.status
+				)
+			)
+		if template.template_variables and template.reference_doctype != self.document_type:
+			frappe.throw(
+				_("Template {0} fills its variables from {1}, but this notification runs on {2}").format(
+					template.name, template.reference_doctype or _("no Document Type"), self.document_type
+				)
+			)
+
+	def send_notification_by_channel(self, doc, context) -> None:
+		if self.channel != WHATSAPP_CHANNEL:
+			return super().send_notification_by_channel(doc, context)
+
+		try:
+			self.send_whatsapp_message(doc, context)
+			# the base class runs this inside the method we just replaced
+			if self.send_system_notification:
+				self.create_system_notification(doc, context)
+		except Exception:
+			log(
+				"Error",
+				"Message",
+				f"Notification {self.name} failed for {doc.doctype} {doc.name}",
+				account=self.get("whatsapp_account"),
+				reference_doctype=get_reference_doctype(doc),
+				reference_docname=get_reference_name(doc),
+				traceback=frappe.get_traceback(),
+			)
+
+	def send_whatsapp_message(self, doc, context) -> None:
+		account = self.get("whatsapp_account") or frappe.db.get_single_value(
+			"WhatsApp Settings", "default_account"
+		)
+		if not account:
+			frappe.throw(_("No WhatsApp Account set on the notification or in WhatsApp Settings"))
+
+		numbers = {normalize_phone(number) for number in self.get_receiver_list(doc, context) if number}
+		if not numbers:
+			return
+
+		for number in numbers:
+			profile = get_or_create_profile(number, account)
+			frappe.enqueue(
+				"whatsapp.whatsapp.notification_channel.send_template_message",
+				profile=profile,
+				account=account,
+				template=self.get("whatsapp_template"),
+				reference_doctype=get_reference_doctype(doc),
+				reference_docname=get_reference_name(doc),
+				enqueue_after_commit=True,
+				now=frappe.in_test,
+			)
+
+
+def send_template_message(
+	profile: str,
+	account: str,
+	template: str,
+	reference_doctype: str,
+	reference_docname: str,
+) -> None:
+	message = frappe.new_doc("WhatsApp Message")
+	message.update(
+		{
+			"direction": "Outgoing",
+			"to": profile,
+			"whatsapp_account": account,
+			"is_template": 1,
+			"whatsapp_template": template,
+			"reference_doctype": reference_doctype,
+			"reference_docname": reference_docname,
+		}
+	)
+	message.flags.ignore_permissions = True
+	message.submit()
+
+
+def normalize_phone(number: str) -> str:
+	# resolve_profile_by_phone matches the stored string exactly, and User.mobile_no is free-form
+	return "".join(character for character in number if character.isdigit())

--- a/whatsapp/whatsapp/test_notification.py
+++ b/whatsapp/whatsapp/test_notification.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from whatsapp.whatsapp.notification.whatsapp_message_received.whatsapp_message_received import (
+	PREVIEW_LIMIT,
+	_message_preview,
+)
+
+STANDARD_NOTIFICATIONS = (
+	"WhatsApp Message Received",
+	"WhatsApp Message Sent",
+	"WhatsApp Message Send Failed",
+	"WhatsApp Message Status Updated",
+	"WhatsApp Template Approved",
+	"WhatsApp Template Rejected",
+)
+
+
+def _message(message="", mime_type=None):
+	return frappe._dict(message=message, mime_type=mime_type)
+
+
+class IntegrationTestMessagePreview(IntegrationTestCase):
+	def test_text_is_returned_as_is(self):
+		self.assertEqual(_message_preview(_message("Is the booking confirmed?")), "Is the booking confirmed?")
+
+	def test_html_is_stripped(self):
+		self.assertEqual(_message_preview(_message("<b>Bold</b> and <i>italic</i>")), "Bold and italic")
+
+	def test_long_text_is_truncated_with_an_ellipsis(self):
+		preview = _message_preview(_message("x" * 300))
+		self.assertEqual(len(preview), PREVIEW_LIMIT + 1)
+		self.assertTrue(preview.endswith("…"))
+
+	def test_short_text_keeps_no_ellipsis(self):
+		self.assertFalse(_message_preview(_message("x" * PREVIEW_LIMIT)).endswith("…"))
+
+	def test_media_is_named_rather_than_called_media(self):
+		for mime_type, expected in (
+			("image/jpeg", "Photo"),
+			("image/webp", "Photo"),
+			("video/mp4", "Video"),
+			("audio/ogg", "Audio message"),
+			("application/pdf", "Document"),
+		):
+			with self.subTest(mime_type=mime_type):
+				self.assertEqual(_message_preview(_message(mime_type=mime_type)), expected)
+
+	def test_reaction_previews_as_the_emoji(self):
+		self.assertEqual(_message_preview(_message("👍")), "👍")
+
+	def test_empty_message_without_media_previews_as_blank(self):
+		self.assertEqual(_message_preview(_message()), "")
+
+
+class IntegrationTestStandardNotifications(IntegrationTestCase):
+	def test_every_rule_sets_an_in_app_title_and_message(self):
+		"""create_system_notification takes description ONLY from notification_message —
+		a blank one leaves NotificationLog to backfill it with the email HTML."""
+		for name in STANDARD_NOTIFICATIONS:
+			with self.subTest(notification=name):
+				rule = frappe.get_doc("Notification", name)
+				self.assertTrue(rule.notification_title, f"{name} has no notification_title")
+				self.assertTrue(rule.notification_message, f"{name} has no notification_message")

--- a/whatsapp/whatsapp/test_notification_channel.py
+++ b/whatsapp/whatsapp/test_notification_channel.py
@@ -1,0 +1,302 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import json
+import secrets
+from unittest.mock import patch
+
+import frappe
+from frappe.email.doctype.notification.notification import clear_notification_cache
+from frappe.tests import IntegrationTestCase
+
+from whatsapp.install import setup_notification_channel
+from whatsapp.whatsapp.notification_channel import normalize_phone
+
+
+class IntegrationTestNotificationChannel(IntegrationTestCase):
+	"""The WhatsApp channel added to the stock Notification doctype."""
+
+	def setUp(self):
+		super().setUp()
+		frappe.set_user("Administrator")
+		self._make_settings()
+		self._silence_other_todo_notifications()
+
+	# -------------------------------------------------------------------------
+	# helpers
+	# -------------------------------------------------------------------------
+
+	def _silence_other_todo_notifications(self) -> None:
+		"""The module runs in one transaction, so rules built by earlier tests are still visible
+		here — as are whatever rules the site already has on ToDo."""
+		frappe.db.set_value(
+			"Notification", {"document_type": "ToDo", "enabled": 1}, "enabled", 0, update_modified=False
+		)
+		clear_notification_cache()
+
+	def _make_settings(self) -> None:
+		settings = frappe.get_single("WhatsApp Settings")
+		settings.whatsapp_api_url = "https://graph.facebook.com"
+		settings.whatsapp_api_version = "v22.0"
+		settings.save()
+
+	def _make_account(self) -> str:
+		uid = frappe.generate_hash(length=6)
+		return (
+			frappe.get_doc(
+				doctype="WhatsApp Account",
+				account_name=f"_Test Notif Account {uid}",
+				status="Active",
+				phone_id=f"phone_{uid}",
+				business_id="test_business",
+				app_id="test_app",
+				access_token="test_token",
+			)
+			.insert()
+			.name
+		)
+
+	def _make_template(self, account: str, **overrides) -> str:
+		uid = frappe.generate_hash(length=6)
+		data = dict(
+			doctype="WhatsApp Template",
+			template_label=f"_Test Notif Template {uid}",
+			template_name=f"_test_notif_template_{uid}",
+			template_type="Utility",
+			language="en_US",
+			message="Reminder: {{description}}",
+			whatsapp_account=account,
+			whatsapp_template_id=uid,
+			status="Approved",
+			variable_format="Named",
+			reference_doctype="ToDo",
+			template_variables=[
+				{
+					"variable_name": "description",
+					"variable_example": "Buy milk",
+					"variable_field": "description",
+				}
+			],
+		)
+		data.update(overrides)
+		return frappe.get_doc(data).insert().name
+
+	def _make_notification(self, **overrides) -> str:
+		uid = frappe.generate_hash(length=6)
+		data = dict(
+			doctype="Notification",
+			subject=f"_Test WhatsApp Notification {uid}",
+			document_type="ToDo",
+			event="New",
+			channel="WhatsApp",
+			enabled=1,
+			recipients=[{"receiver_by_role": "Administrator"}],
+		)
+		data.update(overrides)
+		return frappe.get_doc(data).insert().name
+
+	def _make_todo(self, description: str = "Ship the release") -> str:
+		return frappe.get_doc(doctype="ToDo", description=description).insert().name
+
+	def _set_admin_mobile(self) -> str:
+		"""Give Administrator a fresh number per test and return its digits.
+
+		Reusing one number across tests collides on WhatsApp Profile's autoname once a second
+		account is involved — see get_or_create_profile."""
+		digits = f"9198{secrets.randbelow(10**8):08d}"
+		frappe.db.set_value("User", "Administrator", "mobile_no", f"+{digits[:2]} {digits[2:7]} {digits[7:]}")
+		return digits
+
+	def _messages_for(self, todo: str) -> list[dict]:
+		return frappe.get_all(
+			"WhatsApp Message",
+			filters={"reference_doctype": "ToDo", "reference_docname": todo},
+			fields=["name", "to", "status", "is_template", "whatsapp_template", "template_body_parameters"],
+		)
+
+	# -------------------------------------------------------------------------
+	# setup / schema
+	# -------------------------------------------------------------------------
+
+	def test_channel_option_and_custom_fields_exist(self):
+		meta = frappe.get_meta("Notification")
+		self.assertIn("WhatsApp", meta.get_field("channel").options.split("\n"))
+		self.assertTrue(meta.get_field("whatsapp_template"))
+		self.assertTrue(meta.get_field("whatsapp_account"))
+
+	def test_subject_stays_visible_and_message_section_hides(self):
+		"""Notification.autoname is `subject or notification_title` — a hidden Subject would
+		leave every WhatsApp rule with a hash name."""
+		meta = frappe.get_meta("Notification")
+		self.assertIn("WhatsApp", meta.get_field("subject").depends_on)
+		self.assertIn("WhatsApp", meta.get_field("subject").mandatory_depends_on)
+		self.assertIn("!= 'WhatsApp'", meta.get_field("message_sb").depends_on)
+
+	def test_setup_is_idempotent(self):
+		setup_notification_channel()
+		setup_notification_channel()
+
+		for fieldname, property_name in (("channel", "options"), ("subject", "depends_on")):
+			self.assertEqual(
+				frappe.db.count(
+					"Property Setter",
+					{"doc_type": "Notification", "field_name": fieldname, "property": property_name},
+				),
+				1,
+			)
+
+		options = frappe.get_meta("Notification").get_field("channel").options
+		self.assertEqual(options.split("\n").count("WhatsApp"), 1)
+
+	# -------------------------------------------------------------------------
+	# dispatch
+	# -------------------------------------------------------------------------
+
+	@patch("frappe.email.doctype.notification.notification.Notification.send_an_email")
+	def test_email_channel_is_untouched(self, mock_email):
+		self._make_notification(
+			channel="Email",
+			message="Plain body",
+			recipients=[{"receiver_by_role": "Administrator"}],
+		)
+		self._make_todo()
+
+		mock_email.assert_called_once()
+
+	@patch("whatsapp.whatsapp.api.whatsapp.WhatsApp.send_message")
+	def test_whatsapp_channel_sends_template_message(self, mock_send):
+		mock_send.return_value = {"messages": [{"id": "wamid.notif_test"}]}
+		mobile = self._set_admin_mobile()
+		account = self._make_account()
+		template = self._make_template(account)
+		self._make_notification(whatsapp_template=template, whatsapp_account=account)
+
+		todo = self._make_todo("Ship the release")
+
+		messages = self._messages_for(todo)
+		self.assertEqual(len(messages), 1)
+		self.assertEqual(messages[0].is_template, 1)
+		self.assertEqual(messages[0].whatsapp_template, template)
+		self.assertEqual(messages[0].status, "Sent")
+
+		profile = frappe.get_doc("WhatsApp Profile", messages[0].to)
+		self.assertEqual(profile.phone_number, mobile)
+
+	@patch("whatsapp.whatsapp.api.whatsapp.WhatsApp.send_message")
+	def test_template_variables_come_from_the_triggering_document(self, mock_send):
+		mock_send.return_value = {"messages": [{"id": "wamid.vars"}]}
+		self._set_admin_mobile()
+		account = self._make_account()
+		template = self._make_template(account)
+		self._make_notification(whatsapp_template=template, whatsapp_account=account)
+
+		todo = self._make_todo("Renew the domain")
+
+		body = json.loads(self._messages_for(todo)[0].template_body_parameters or "{}")
+		self.assertEqual(body, {"description": "Renew the domain"})
+
+	@patch("whatsapp.whatsapp.api.whatsapp.WhatsApp.send_message")
+	def test_account_falls_back_to_default_when_blank(self, mock_send):
+		mock_send.return_value = {"messages": [{"id": "wamid.default_account"}]}
+		self._set_admin_mobile()
+		account = self._make_account()
+		frappe.db.set_single_value("WhatsApp Settings", "default_account", account)
+		template = self._make_template(account)
+		self._make_notification(whatsapp_template=template)
+
+		todo = self._make_todo()
+
+		self.assertEqual(len(self._messages_for(todo)), 1)
+
+	@patch("whatsapp.whatsapp.api.whatsapp.WhatsApp.send_message")
+	def test_differently_formatted_numbers_collapse_to_one_profile(self, mock_send):
+		mock_send.return_value = {"messages": [{"id": "wamid.dedupe"}]}
+		mobile = self._set_admin_mobile()
+		account = self._make_account()
+		template = self._make_template(account)
+
+		uid = frappe.generate_hash(length=6)
+		role = frappe.get_doc(doctype="Role", role_name=f"_Test WA Role {uid}").insert().name
+		frappe.get_doc(
+			doctype="User",
+			email=f"_test_wa_{uid}@example.com",
+			first_name="Test WA",
+			mobile_no=mobile,
+			roles=[{"role": role}],
+		).insert()
+
+		self._make_notification(
+			whatsapp_template=template,
+			whatsapp_account=account,
+			recipients=[{"receiver_by_role": "Administrator"}, {"receiver_by_role": role}],
+		)
+
+		todo = self._make_todo()
+
+		self.assertEqual(len(self._messages_for(todo)), 1)
+		self.assertEqual(
+			frappe.db.count(
+				"WhatsApp Profile",
+				{"phone_number": mobile, "whatsapp_account": account},
+			),
+			1,
+		)
+
+	@patch("whatsapp.whatsapp.api.whatsapp.WhatsApp.send_message")
+	def test_no_recipients_sends_nothing(self, mock_send):
+		frappe.db.set_value("User", "Administrator", "mobile_no", None)
+		account = self._make_account()
+		template = self._make_template(account)
+		self._make_notification(whatsapp_template=template, whatsapp_account=account)
+
+		todo = self._make_todo()
+
+		self.assertEqual(self._messages_for(todo), [])
+		mock_send.assert_not_called()
+
+	# -------------------------------------------------------------------------
+	# validation
+	# -------------------------------------------------------------------------
+
+	def test_template_is_required(self):
+		with self.assertRaises(frappe.ValidationError):
+			self._make_notification()
+
+	def test_unapproved_template_is_rejected(self):
+		account = self._make_account()
+		template = self._make_template(account, status="Pending")
+		with self.assertRaises(frappe.ValidationError):
+			self._make_notification(whatsapp_template=template, whatsapp_account=account)
+
+	def test_template_reference_doctype_must_match_document_type(self):
+		account = self._make_account()
+		template = self._make_template(account, reference_doctype="User")
+		with self.assertRaises(frappe.ValidationError):
+			self._make_notification(whatsapp_template=template, whatsapp_account=account)
+
+	# -------------------------------------------------------------------------
+	# failure handling
+	# -------------------------------------------------------------------------
+
+	@patch("whatsapp.whatsapp.api.whatsapp.WhatsApp.send_message")
+	def test_send_failure_is_logged_and_does_not_break_the_trigger(self, mock_send):
+		from requests import HTTPError
+
+		mock_send.side_effect = HTTPError("API Error: Rate limit exceeded")
+		self._set_admin_mobile()
+		account = self._make_account()
+		template = self._make_template(account)
+		notification = self._make_notification(whatsapp_template=template, whatsapp_account=account)
+
+		todo = self._make_todo()
+
+		self.assertTrue(frappe.db.exists("ToDo", todo))
+		self.assertTrue(
+			frappe.db.exists(
+				"WhatsApp Log",
+				{"level": "Error", "message": ("like", f"%{notification}%")},
+			)
+		)
+
+	def test_normalize_phone_keeps_digits_only(self):
+		self.assertEqual(normalize_phone("+91 (98765) 43210"), "919876543210")

--- a/whatsapp/whatsapp/test_webhook.py
+++ b/whatsapp/whatsapp/test_webhook.py
@@ -196,7 +196,7 @@ class TestWebhookNotifications(IntegrationTestCase):
 			doctype="WhatsApp Template",
 			template_label=f"_Test Tmpl {uid}",
 			template_name=f"_test_tmpl_{uid}",
-			template_type="UTILITY",
+			template_type="Utility",
 			language="en_US",
 			message="Hello",
 			whatsapp_account=account,


### PR DESCRIPTION
Three independent commits.

### `feat(notification)` — WhatsApp channel for Frappe Notification

Adds `WhatsApp` as a Notification channel via `extend_doctype_class`, with custom fields for template and account. Set up on install/migrate, torn down on uninstall.

### `refactor(template)!` — title case template enum values

Meta's all-caps values were stored verbatim; the framework spells user-facing Select options in Title Case. This finishes what `capitalize_template_status` started for `status`.

| Field | Before | After |
|---|---|---|
| `template_type` | `UTILITY` | `Utility` |
| `header_type` | `IMAGE` | `Image` |
| `button_type` | `QUICK_REPLY` | `Quick Reply` |
| `variable_format` | `named` | `Named` |

Meta's spelling is now confined to three maps in `api/utils.py`, translated on the way in and out.

**Breaking:** stored values change. `patches/v1_0/titlecase_template_enums.py` migrates existing rows; external code comparing against `"UTILITY"` needs updating.

### `feat(notification)` — in-app title and message on the six standard notifications

Catches the six shipped rules up with the `notification_title` / `notification_message` split. Previously they set only `subject`, so `NotificationLog.before_insert` backfilled `description` from `email_content` — putting a full HTML email table in the notification panel.

Each rule now carries a one-line headline and body. The `.html` files are unchanged and still feed `email_content`.

For an inbound message the body is the text itself, stripped and truncated, or the kind of media that arrived — Photo, Video, Audio message, Document — rather than a generic "media" label. Derived from `mime_type` via the existing `infer_content_type`.

Note the bumped `modified` timestamps: `import_file` skips a shipped record whose file timestamp isn't newer than the DB row, so without them the change would never reach an existing site.

### Testing

`bench run-tests --app whatsapp` — 109 tests, one pre-existing unrelated failure. `bench migrate` verified both the enum patch and the notification reload against real rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)