### PR TITLE
feat: manage the default whatsapp account automatically

### DIFF
--- a/whatsapp/patches.txt
+++ b/whatsapp/patches.txt
@@ -8,3 +8,4 @@ whatsapp.patches.v1_0.rename_whatsapp_to_whatsappcased
 whatsapp.patches.v1_0.encrypt_account_access_token
 whatsapp.patches.v1_0.capitalize_template_status
 whatsapp.patches.v1_0.titlecase_template_enums
+whatsapp.patches.v1_0.set_default_account_when_only_one

--- a/whatsapp/patches/v1_0/set_default_account_when_only_one.py
+++ b/whatsapp/patches/v1_0/set_default_account_when_only_one.py
@@ -1,0 +1,17 @@
+import frappe
+
+
+def execute():
+	"""Point `WhatsApp Settings.default_account` at the only account, where there is one.
+
+	A default is now set automatically when the first account is created, so a
+	single-account site never has to pick one. Existing sites created before that
+	may have one account and no default, which leaves WhatsApp switched off in CRM
+	(crm.api.whatsapp.is_whatsapp_enabled requires a default). Fill it in.
+	"""
+	if frappe.db.get_single_value("WhatsApp Settings", "default_account"):
+		return
+
+	accounts = frappe.get_all("WhatsApp Account", pluck="name", limit=2)
+	if len(accounts) == 1:
+		frappe.db.set_single_value("WhatsApp Settings", "default_account", accounts[0])

--- a/whatsapp/whatsapp/doctype/whatsapp_account/test_whatsapp_account.py
+++ b/whatsapp/whatsapp/doctype/whatsapp_account/test_whatsapp_account.py
@@ -1,9 +1,8 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests import IntegrationTestCase
-
 
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
@@ -12,11 +11,67 @@ EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
-
 class IntegrationTestWhatsAppAccount(IntegrationTestCase):
 	"""
 	Integration tests for WhatsAppAccount.
 	Use this class for testing interactions between multiple components.
 	"""
 
-	pass
+	def setUp(self):
+		# after_insert only claims an empty default, so start from one.
+		frappe.db.set_single_value("WhatsApp Settings", "default_account", "")
+
+	def _account(self, suffix):
+		# IntegrationTestCase rolls back once per class, not per test, so accounts
+		# outlive the test that made them. Namespace them to avoid collisions.
+		return frappe.get_doc(
+			doctype="WhatsApp Account",
+			account_name=f"_Test {self._testMethodName} {suffix}",
+			status="Active",
+			phone_id=f"1555000{suffix}",
+			access_token="test_token",
+		).insert()
+
+	def _default(self):
+		return frappe.db.get_single_value("WhatsApp Settings", "default_account")
+
+	def test_first_account_becomes_the_default(self):
+		account = self._account("A")
+
+		self.assertEqual(self._default(), account.name)
+
+	def test_second_account_leaves_the_default_alone(self):
+		first = self._account("A")
+		self._account("B")
+
+		self.assertEqual(self._default(), first.name)
+
+	def test_deleting_the_default_is_refused_while_others_remain(self):
+		first = self._account("A")
+		self._account("B")
+
+		with self.assertRaises(frappe.ValidationError):
+			first.delete()
+
+		self.assertEqual(self._default(), first.name)
+		self.assertTrue(frappe.db.exists("WhatsApp Account", first.name))
+
+	def test_deleting_a_non_default_leaves_the_default_intact(self):
+		first = self._account("A")
+		second = self._account("B")
+
+		second.delete()
+
+		self.assertEqual(self._default(), first.name)
+		self.assertTrue(frappe.db.exists("WhatsApp Account", first.name))
+
+	def test_deleting_the_last_account_clears_the_default(self):
+		# The only test that needs an empty table: on_trash distinguishes "last
+		# account" from "one of several". Rolled back with the rest of the class.
+		frappe.db.delete("WhatsApp Account")
+		account = self._account("A")
+
+		account.delete()
+
+		self.assertFalse(self._default())
+		self.assertFalse(frappe.db.exists("WhatsApp Account", account.name))

--- a/whatsapp/whatsapp/doctype/whatsapp_account/whatsapp_account.py
+++ b/whatsapp/whatsapp/doctype/whatsapp_account/whatsapp_account.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
@@ -27,4 +28,27 @@ class WhatsAppAccount(Document):
 		status: DF.Literal["Active", "Inactive"]
 	# end: auto-generated types
 
-	pass
+	def after_insert(self):
+		"""Make the first account the default, so a site with one account never has
+		to choose one. Later accounts leave the existing default alone."""
+		if not frappe.db.get_single_value("WhatsApp Settings", "default_account"):
+			frappe.db.set_single_value("WhatsApp Settings", "default_account", self.name)
+
+	def on_trash(self):
+		"""Stop `WhatsApp Settings.default_account` ever naming a deleted account.
+
+		Frappe runs on_trash before its link check (frappe/model/delete_doc.py), so
+		clearing the value here is also what lets the last account be deleted at all
+		— the Singles link check would otherwise refuse it.
+		"""
+		if frappe.db.get_single_value("WhatsApp Settings", "default_account") != self.name:
+			return
+
+		if frappe.db.count("WhatsApp Account", {"name": ("!=", self.name)}):
+			frappe.throw(
+				_("{0} is the default WhatsApp account. Set another account as the default before deleting it.").format(
+					self.name
+				)
+			)
+
+		frappe.db.set_single_value("WhatsApp Settings", "default_account", "")


### PR DESCRIPTION
The first account added becomes the default. Deleting the default is blocked while other accounts exist, and deleting the last account clears it.

Adds a patch to fill in the default on sites that already have one account.