### PR TITLE
fix(template): include Read Only and Date fieldtypes in variable_field options

### DIFF
--- a/whatsapp/whatsapp/doctype/whatsapp_template/whatsapp_template.py
+++ b/whatsapp/whatsapp/doctype/whatsapp_template/whatsapp_template.py
@@ -533,7 +533,7 @@ def get_doctype_columns(doctype: str) -> list[str]:
 	return [
 		df.fieldname
 		for df in meta.fields
-		if df.fieldtype in ("Data", "Link", "Select", "Small Text", "Text")
+		if df.fieldtype in ("Data", "Link", "Select", "Small Text", "Text", "Read Only", "Date")
 	]
 
 


### PR DESCRIPTION
## Summary

Fixes #9

`Template Variable.variable_field`'s dropdown options come from `get_doctype_columns()`,
which only allowed `Data`, `Link`, `Select`, `Small Text`, `Text` fieldtypes. This silently
excluded common, legitimate mapping targets:

- `Read Only` fields — e.g. `Salary Slip.employee_name`, a fetched value from the `employee`
  Link. This is a very common pattern for exposing a related doc's display value.
- `Date` fields — e.g. `Salary Slip.start_date` / `end_date`.

Value resolution at send time (`whatsapp_message.py`, `_populate_template_parameters`) does
`ref_doc.get(var.variable_field)`, which works the same regardless of fieldtype, so nothing
downstream needed to change.

## Change

One-line diff in `get_doctype_columns()`:

```diff
- if df.fieldtype in ("Data", "Link", "Select", "Small Text", "Text")
+ if df.fieldtype in ("Data", "Link", "Select", "Small Text", "Text", "Read Only", "Date")
```

## Test plan

- [x] Verified via `get_doctype_columns("Salary Slip")` that `employee_name`, `start_date`,
      and `end_date` are now included in the returned field list.
- [x] Created a `WhatsApp Template` with Reference DocType `Salary Slip` mapping
      `employee_name` and `start_date` through the dropdown, confirmed values resolve
      correctly via `ref_doc.get(fieldname)`.